### PR TITLE
fix: dtstart parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 'Use NodeJS 18'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.13.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@vendpark'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      - name: 'Lint'
+        run: npm run lint
+
+      - name: 'Test'
+        run: npm run test
+
+      - name: 'Build'
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 **Library for working with recurrence rules for calendar dates.**
 
-[![NPM version][npm-image]][npm-url]
-[![Build Status][ci-image]][ci-url]
-[![js-standard-style][js-standard-image]][js-standard-url]
-[![Downloads][downloads-image]][downloads-url]
-[![Gitter][gitter-image]][gitter-url]
-[![codecov.io](http://codecov.io/github/jakubroztocil/rrule/coverage.svg?branch=master)](http://codecov.io/github/jakubroztocil/rrule?branch=master)
+[![Test](https://github.com/vendpark/rrule/actions/workflows/test.yml/badge.svg)](https://github.com/vendpark/rrule/actions/workflows/test.yml)
 
 rrule.js supports recurrence rules as defined in the [iCalendar
 RFC](https://tools.ietf.org/html/rfc5545), with a few important
@@ -717,45 +712,45 @@ Additionally, it accepts the following keyword arguments:
 
 <dt><code>cache</code></dt>
 <dd>
-If <code>true</code>, the <code>rruleset</code> or <code>rrule</code> created instance 
+If <code>true</code>, the <code>rruleset</code> or <code>rrule</code> created instance
 will cache its results.
 Default is not to cache.
 </dd>
 
 <dt><code>dtstart</code></dt>
 <dd>
-If given, it must be a datetime instance that will be used when no 
-<code>DTSTART</code> property is found in the parsed string. 
-If it is not given, and the property is not found, 
+If given, it must be a datetime instance that will be used when no
+<code>DTSTART</code> property is found in the parsed string.
+If it is not given, and the property is not found,
 <code>datetime.now()</code> will be used instead.
 </dd>
 
 <dt><code>unfold</code></dt>
 <dd>
-If set to <code>true</code>, lines will be unfolded following the RFC specification. 
+If set to <code>true</code>, lines will be unfolded following the RFC specification.
 It defaults to <code>false</code>, meaning that spaces before every line will be stripped.
 </dd>
 
 <dt><code>forceset</code></dt>
 <dd>
-If set to <code>true</code>, an <code>rruleset</code> instance will be returned, 
-even if only a single rule is found. 
-The default is to return an <code>rrule</code> if possible, and 
+If set to <code>true</code>, an <code>rruleset</code> instance will be returned,
+even if only a single rule is found.
+The default is to return an <code>rrule</code> if possible, and
 an <code>rruleset</code> if necessary.
 </dd>
 
 <dt><code>compatible</code></dt>
 <dd>
-If set to <code>true</code>, the parser will operate in RFC-compatible mode. 
-Right now it means that unfold will be turned on, and if a <code>DTSTART</code> is found, 
+If set to <code>true</code>, the parser will operate in RFC-compatible mode.
+Right now it means that unfold will be turned on, and if a <code>DTSTART</code> is found,
 it will be considered the first recurrence instance, as documented in the RFC.
 </dd>
 
 <dt><code>tzid</code></dt>
 <dd>
-If given, it must be a string that will be used when no <code>TZID</code> 
-property is found in the parsed string. 
-If it is not given, and the property is not found, <code>'UTC'</code> will 
+If given, it must be a string that will be used when no <code>TZID</code>
+property is found in the parsed string.
+If it is not given, and the property is not found, <code>'UTC'</code> will
 be used by default.
 </dd>
 

--- a/src/rrulestr.ts
+++ b/src/rrulestr.ts
@@ -110,13 +110,13 @@ function buildRule(s: string, options: Partial<RRuleStrOptions>) {
   ) {
     const rset = new RRuleSet(noCache)
 
-    rset.dtstart(options.dtstart || dtstart)
+    rset.dtstart(dtstart || options.dtstart)
     rset.tzid(tzid || undefined)
 
     rrulevals.forEach((val) => {
       rset.rrule(
         new RRule(
-          groomRruleOptions(val, options.dtstart || dtstart, tzid),
+          groomRruleOptions(val, dtstart || options.dtstart, tzid),
           noCache
         )
       )
@@ -129,7 +129,7 @@ function buildRule(s: string, options: Partial<RRuleStrOptions>) {
     exrulevals.forEach((val) => {
       rset.exrule(
         new RRule(
-          groomRruleOptions(val, options.dtstart || dtstart, tzid),
+          groomRruleOptions(val, dtstart || options.dtstart, tzid),
           noCache
         )
       )
@@ -140,7 +140,7 @@ function buildRule(s: string, options: Partial<RRuleStrOptions>) {
     })
 
     if (options.compatible && options.dtstart) {
-      rset.rdate(options.dtstart || dtstart)
+      rset.rdate(dtstart || options.dtstart)
     }
     return rset
   }
@@ -149,7 +149,7 @@ function buildRule(s: string, options: Partial<RRuleStrOptions>) {
   return new RRule(
     groomRruleOptions(
       val,
-      val.dtstart || options.dtstart || dtstart,
+      val.dtstart || dtstart || options.dtstart,
       val.tzid || options.tzid || tzid
     ),
     noCache

--- a/test/rrulestr.test.ts
+++ b/test/rrulestr.test.ts
@@ -295,30 +295,28 @@ describe('rrulestr', function () {
   })
 
   it('adds dtstart when forceset is applied', () => {
+    const dtstart = new Date(Date.UTC(1997, 8, 2, 9, 0, 0))
     const rruleset = rrulestr('RRULE:FREQ=WEEKLY', {
       forceset: true,
-      dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0)),
-    })
+      dtstart,
+    }) as RRuleSet
 
-    expect(rruleset.valueOf()).to.deep.equal([
-      'DTSTART:19970902T090000Z',
-      'RRULE:FREQ=WEEKLY',
-    ])
+    expect(rruleset.dtstart()).to.deep.equal(dtstart)
   })
 
-  it("adds dtstart from options overriding rule's dtstart", () => {
+  it("Uses the rrule's DTSTART even if one is passed into the constructor", () => {
+    const dtstart = new Date(Date.UTC(1997, 8, 2, 9, 0, 0))
     const rruleset = rrulestr(
       'RRULE:DTSTART=19990104T110000Z;FREQ=WEEKLY;BYDAY=TU,WE',
       {
         forceset: true,
-        dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0)),
+        dtstart,
       }
-    )
+    ) as RRuleSet
 
-    expect(rruleset.valueOf()).to.deep.equal([
-      'DTSTART:19970902T090000Z',
-      'RRULE:FREQ=WEEKLY;BYDAY=TU,WE',
-    ])
+    expect(rruleset.dtstart()).to.deep.equal(
+      new Date(Date.UTC(1999, 0, 4, 11, 0, 0))
+    )
   })
 
   it('parses a DTSTART inside an RRULE', () => {


### PR DESCRIPTION
Take the incoming rules `DTSTART` over the constructors `dtstart` value.   Only use the constructors `dtstart` if the rule string didnt specify a start